### PR TITLE
在 bootstrap 3 中網頁上方無法出現圖片

### DIFF
--- a/config.php
+++ b/config.php
@@ -353,5 +353,5 @@ switch ($op) {
 }
 
 /*-----------秀出結果區--------------*/
-include_once '/footer.php';
+include_once './footer.php';
 include_once XOOPS_ROOT_PATH . '/footer.php';

--- a/index.php
+++ b/index.php
@@ -129,5 +129,5 @@ switch ($op) {
 }
 
 /*-----------秀出結果區--------------*/
-include_once '/footer.php';
+include_once './footer.php';
 include_once XOOPS_ROOT_PATH . '/footer.php';

--- a/xoops_version.php
+++ b/xoops_version.php
@@ -275,6 +275,15 @@ $i++;
 $modversion['templates'][$i]['file']        = 'tad_web_common_works_b3.html';
 $modversion['templates'][$i]['description'] = 'tad_web_common_works_b3.html';
 
+$i++;
+$modversion['templates'][$i]['file']        = 'tad_web_header.html';
+$modversion['templates'][$i]['description'] = 'tad_web_header.html';
+
+$i++;
+$modversion['templates'][$i]['file']        = 'tad_web_header_b3.html';
+$modversion['templates'][$i]['description'] = 'tad_web_header_b3.html';
+
+
 //---區塊設定---//
 $i                                       = 1;
 $modversion['blocks'][$i]['file']        = "tad_web_menu.php";


### PR DESCRIPTION
安裝 tad_web 1.2 版，一直無法出現上方圖片

xoops_version.php 加入 tad_web_header_b3.html 樣版

修改 config 、 index.php 
include_once '/footer.php'; 

另外，如果不小心把 logo 拉出了範圍，有沒有還原機制。
還有 for_tad_web_theme 多人網頁用佈景（非網站佈景） 更新後，一直出現要更新紅色鈕。
